### PR TITLE
Ability to reset expectations

### DIFF
--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -1202,7 +1202,7 @@ impl<'a> ToTokens for CommonExpectationsMethods<'a> {
                 }
 
                 /// Remove all existing expectations.
-                #v fn reset(&mut self) -> &mut Self #tg
+                #v fn reset(&mut self) -> &mut Expectations #tg
                 {
                     self.0.clear();
                     self
@@ -2445,6 +2445,11 @@ impl<'a> ToTokens for GenericExpectations<'a> {
                                Box<dyn ::mockall::AnyExpectations>>
                 {
                     self.store.drain()
+                }
+
+                #v fn reset(&mut self) -> &mut GenericExpectations {
+                    self.store.clear();
+                    self
                 }
 
                 #v fn new() -> Self {


### PR DESCRIPTION
I've been using this unit test pattern where you can reuse a group of mocked objects across multiple tests by having a setup function that initializes them for the happy case. Then, individual tests only need to make the required modifications to the mock behavior.

Unfortunately, this doesn't work with `mockall` out of the box because once an expectation has been assigned, it cannot be overwritten.

This PR adds `reset_<method_name>()` methods to auto-generated mocks that replace all existing expectations with the new one.

```rust
#[mockall::automock]
trait Getter {
    fn get(&self) -> String;
}

fn setup() -> MockGetter {
    let mut m = MockGetter::new();
    m.expect_get().return_const::<String>("A".into());
    m
}

fn main() {
    let mut m = setup();
    println!("get = {}", m.get()); // prints "A"
    m.expect_get().return_const::<String>("B".into());
    println!("get = {}", m.get()); // prints "A"

    m.reset_get().return_const::<String>("C".into());
    println!("get = {}", m.get()); // prints "C"
}
```