### PR TITLE
Bugfix: allow lifetimes and generics

### DIFF
--- a/mockall_derive/src/mock_function.rs
+++ b/mockall_derive/src/mock_function.rs
@@ -2466,7 +2466,7 @@ impl<'a> ToTokens for GenericExpectations<'a> {
         if ! self.f.is_static() && ! self.f.is_method_generic() {
             return;
         }
-
+        let lg = lifetimes_to_generics(&self.f.alifetimes);
         let ge = StaticGenericExpectations{f: self.f};
         let v = &self.f.privmod_vis;
         quote!(
@@ -2479,7 +2479,7 @@ impl<'a> ToTokens for GenericExpectations<'a> {
                 store: std::collections::hash_map::HashMap<::mockall::Key,
                                Box<dyn ::mockall::AnyExpectations>>
             }
-            impl GenericExpectations {
+            impl #lg GenericExpectations {
                 /// Verify that all current expectations are satisfied and clear
                 /// them.  This applies to all sets of generic parameters!
                 #v fn checkpoint(&mut self) ->
@@ -2514,6 +2514,7 @@ impl<'a> ToTokens for StaticGenericExpectations<'a> {
         let argnames = &self.f.argnames;
         let argty = &self.f.argty;
         let (ig, tg, wc) = self.f.egenerics.split_for_impl();
+        let lg = lifetimes_to_generics(&self.f.alifetimes);
         let keyid = gen_keyid(&self.f.egenerics);
         let mut any_wc = wc.cloned();
         if self.f.return_ref || self.f.return_refmut {
@@ -2537,7 +2538,7 @@ impl<'a> ToTokens for StaticGenericExpectations<'a> {
         };
         quote!(
             impl #ig ::mockall::AnyExpectations for Expectations #tg #any_wc {}
-            impl GenericExpectations {
+            impl #lg GenericExpectations {
                 /// Simulating calling the real method.
                 #v fn #call #ig (#self_, #(#argnames: #argty, )* )
                     -> Option<#output> #wc


### PR DESCRIPTION
Before

```rust
#[automock]
trait Component {
    fn do_generic_stuff<'c, C: 'static>(&self, c: &'c C);
}
```

```
error[E0261]: use of undeclared lifetime name `'c`
 --> src/main.rs:5:52
  |
3 | #[automock]
  |            - lifetime `'c` is missing in item created through this procedural macro
4 | trait Component {
5 |     fn do_generic_stuff<'c, C: 'static>(&self, c: &'c C);
  |                         -                          ^^ undeclared lifetime
  |                         |
  |                         help: consider introducing lifetime `'c` here: `'c,`
```

After:
👍 👍 